### PR TITLE
add NLR to the Widescreen code for Playback

### DIFF
--- a/Output/Playback/GALE01r2.ini
+++ b/Output/Playback/GALE01r2.ini
@@ -1101,6 +1101,8 @@ C0030000 4800000C
 4E800021 40DC7AE1
 60000000 00000000
 044DDB84 3E89FEFA #External/Widescreen/Nametag Fixes/Adjust Nametag Text X Scale.asm
+043761EC 4800001C #Normal Lag Reduction [Hannes Mann]
+04376238 48000018
 
 $Optional: Disable Screen Shake [Achilles1515]
 *Disables all screen shaking

--- a/Output/Playback/GALJ01r2.ini
+++ b/Output/Playback/GALJ01r2.ini
@@ -1101,6 +1101,8 @@ C0030000 4800000C
 4E800021 40DC7AE1
 60000000 00000000
 044DDB84 3E89FEFA #External/Widescreen/Nametag Fixes/Adjust Nametag Text X Scale.asm
+043761EC 4800001C #Normal Lag Reduction [Hannes Mann]
+04376238 48000018
 
 $Optional: Disable Screen Shake [Achilles1515]
 *Disables all screen shaking

--- a/playback.json
+++ b/playback.json
@@ -184,6 +184,11 @@
           "sourceFolder": "External/Widescreen",
           "isRecursive": true,
           "annotation": "Widescreen 16:9"
+        },
+        {
+          "type": "binary",
+          "sourceFile": "Binary/NormalLagReduction.bin",
+          "annotation": "Normal Lag Reduction [Hannes Mann]"
         }
       ]
     },


### PR DESCRIPTION
for some reason widescreen doesn't fill a 16:9 viewport unless NLR is enabled.