### PR TITLE
Reorder audio pipeline to save ~4ms latency

### DIFF
--- a/External/ReorderAudioPipeline/DoUserFrameCallbackBeforeSyncPBs.asm
+++ b/External/ReorderAudioPipeline/DoUserFrameCallbackBeforeSyncPBs.asm
@@ -1,0 +1,13 @@
+# Address: 80359740
+
+addi r30, r3, 0
+
+lwz r12, -0x4158(r13)
+
+cmplwi r12, 0
+beq end
+
+mtspr lr, r12
+blrl
+
+end:

--- a/External/ReorderAudioPipeline/NoLateUserFrameCallback.asm
+++ b/External/ReorderAudioPipeline/NoLateUserFrameCallback.asm
@@ -1,0 +1,3 @@
+# Address: 803597CC
+
+nop

--- a/Output/Netplay/GALE01r2.ini
+++ b/Output/Netplay/GALE01r2.ini
@@ -7245,6 +7245,15 @@ C21CBB90 00000005 #Lagless FoD
 041CD250 60000000
 041CCDCC 480000B4
 
+$Recommended: Audio Lag Reduction [Arte, Altafen]
+*Reduces audio lag
+C2359740 00000004 #External/ReorderAudioPipeline/DoUserFrameCallbackBeforeSyncPBs.asm
+3BC30000 818DBEA8
+280C0000 4182000C
+7D8803A6 4E800021
+60000000 00000000
+043597CC 60000000 #External/ReorderAudioPipeline/NoLateUserFrameCallback.asm
+
 $Optional: Freeze Final Destination Background [Fizzi]
 *Prevents FD background from changing to improve performance
 0421AAE0 48000008 #External/FreezeFDSlippi/FreezeFDSlippi.asm

--- a/Output/Netplay/GALJ01r2.ini
+++ b/Output/Netplay/GALJ01r2.ini
@@ -7244,6 +7244,15 @@ C21CBB90 00000005 #Lagless FoD
 041CD250 60000000
 041CCDCC 480000B4
 
+$Recommended: Audio Lag Reduction [Arte, Altafen]
+*Reduces audio lag
+C2359740 00000004 #External/ReorderAudioPipeline/DoUserFrameCallbackBeforeSyncPBs.asm
+3BC30000 818DBEA8
+280C0000 4182000C
+7D8803A6 4E800021
+60000000 00000000
+043597CC 60000000 #External/ReorderAudioPipeline/NoLateUserFrameCallback.asm
+
 $Optional: Freeze Final Destination Background [Fizzi]
 *Prevents FD background from changing to improve performance
 0421AAE0 48000008 #External/FreezeFDSlippi/FreezeFDSlippi.asm

--- a/netplay.json
+++ b/netplay.json
@@ -416,6 +416,23 @@
       ]
     },
     {
+      "name": "Recommended: Audio Lag Reduction",
+      "authors": [
+        "Arte",
+        "Altafen"
+      ],
+      "description": [
+        "Reduces audio lag"
+      ],
+      "build": [
+        {
+          "type": "injectFolder",
+          "sourceFolder": "External/ReorderAudioPipeline",
+          "isRecursive": true
+        }
+      ]
+    },
+    {
       "name": "Optional: Freeze Final Destination Background",
       "authors": [
         "Fizzi"


### PR DESCRIPTION
This was developed with Altafen.

<img width="1101" height="1370" alt="image" src="https://github.com/user-attachments/assets/7fdbf738-69c3-4b0e-b929-be65e1d4d8e9" />

The PRd gecko codes have the effect above, which saves latency by reordering the audio pipeline events to make more sense with no observed negative side effect so far.



My understanding of the gist of the audio pipeline is as follows.

When the game creates the next state, it iterates over the SFXs it must play, and creates a data structure that contains information about the sound id, its pitch, its volume, etc, puts it in a global list, these are 'AXVPBs' per the external dolphin/ax decompiled code.

The GC has a DSP coprocessor, called the AX, that handles the heavy lifting for audio data, reading ADPCM encoded audio data, handling pitch, volume, fades, effects, whatever.

There's a function that processes these 'AXVPBs' to make 'AXPBs', which are the processing blocks that are actually going to be sent to the AX (DSP coprocessor) and have information about where in the sound you currently are, among other things. There's a global structure for these 'AXPBs'.

Finally, there's another function of interest, __AXSyncPBs in the decomp, that processes the AXPBs to make the list of those that are actually going to be processed in this pass of the AX.

But the ordering of these functions doesn't appear to make sense.

There is an effectively 5ms-paced event (DSP is done) that resolves to __AXOutNewFrame (picture above) that's the core of the audio pipeline:
- __AXSyncPBs: handles advancing existing AXPBs by 5ms, looping, etc. Then the data gets moved from [AXPBs global structure] to [AXPBs for this AX pass]
- DSPSendMailToDSP: tell the AX to get to work, always the same command list for Melee bar some address ping ponging, "process the AXPB list here"+some AUX stuff
- __AXServiceCallbackStack: handles adding some effects e.g. reverb for FD, iirc
- __AXUserFrameCallback: reads the AXVPBs created from the SFXs and creates AXPBs!
- AIInitDMA: DMAs away the buffer that the AX just transformed

So in other words, if the audio data generated from SFX is structure S1, the AXPB tracking structure is S2, and our processing blocks for this AX pass are S3, then that means first we read S2 and update S3, then we launch processing of S3, then we read S1 and update S2 then go to sleep for 5ms. And so S2 information is 5ms old when we process it (a little less than 5ms because of processing time)

These codes move the S1->S2 step at the start, so that we do S1->S2, S2->S3, launch processing of S3, and then go to sleep. It doesn't seem to interact negatively in any way e.g. with __AXServiceCallbackStack; the reverb effect of FD is still here. This has also been used for months with no problem either (along with https://github.com/project-slippi/Ishiiruka/pull/451).

 I measured 8.7ms total improvement from this+the DMA optim using a physical click-to-line-in lag tester, coherent with the sum of 2 close to 5ms saves:
<img width="673" height="1035" alt="image" src="https://github.com/user-attachments/assets/0a76c4b7-6510-462d-8a5c-db5c254dd716" />

Difference in us between timestamps at key events using the EXI interface for logging:
<img width="1309" height="291" alt="image" src="https://github.com/user-attachments/assets/bc861cd1-3ed0-46ec-91e9-536adbf76d90" />

N.B, the function that makes the AXPB from the AXVPB is at 803896F0, HSD_SynthSFXPlayWithGroup aka Audio_PlaySound2?, called by Audio_SFXCallback, the "user callback":
<img width="3162" height="1886" alt="image" src="https://github.com/user-attachments/assets/8c4ece5f-fd4d-4b06-8a63-211b4880ef8a" />

This results in audio that's ~0.5f faster than console(+pdf) with no slippi delay / ~1.5f slower with, on WASAPI+direct motherboard output.

Please double check files changed as I'm not familiar with the project structure. I've put them in External, not sure if it's the right place.