### PR TITLE
Fix unaligned float write crash on FoD

### DIFF
--- a/Recording/Stages/SendFountainInfo.asm
+++ b/Recording/Stages/SendFountainInfo.asm
@@ -45,7 +45,8 @@
   stb r3,0x5(REG_Buffer)
 
 # send height
-  stfs f31, 0x6(REG_Buffer)
+  lwz r3, 0xd0(r31)
+  stw r3, 0x6(REG_Buffer)
 
 #------------- Increment Buffer Offset ------------
   lwz REG_BufferOffset,bufferOffset(r13)


### PR DESCRIPTION
Console crashes on unaligned float write. This fixes the crash. Test these changes based on my branch. Rebasing/merging to master won't work because there are other issues with the master branch that cause a crash on console.

I have attached short 3.18 replay files for the 3 stages I used to briefly check the outputs were good and parseable in slippi-js. I also included the script I used to display the parsed results:
[stage.zip](https://github.com/user-attachments/files/26364126/stage.zip)

```
DREAMLAND
3.18.0
{ frame: 704, direction: 2 }
{ frame: 978, direction: 0 }

POKEMON STADIUM
3.18.0
{ frame: 3661, event: 2, transformation: 6 }
{ frame: 3662, event: 3, transformation: 6 }
{ frame: 3964, event: 4, transformation: 6 }
{ frame: 4145, event: 5, transformation: 6 }
{ frame: 4266, event: 6, transformation: 6 }
{ frame: 4267, event: 0, transformation: 6 }

FOUNTAIN OF DREAMS
3.18.0
{ frame: 603, platform: 0, height: 27.899999618530273 }
{ frame: 604, platform: 0, height: 27.799999237060547 }
{ frame: 605, platform: 0, height: 27.69999885559082 }
{ frame: 606, platform: 0, height: 27.599998474121094 }
{ frame: 607, platform: 0, height: 27.499998092651367 }
{ frame: 608, platform: 0, height: 27.39999771118164 }
...
```